### PR TITLE
Update conn.py

### DIFF
--- a/conn.py
+++ b/conn.py
@@ -1,8 +1,10 @@
-import redis
 from os import environ as env
+from redis import ConnectionPool, Redis
+
 
 def get_redis():
     # A method to get the redis instance and is used globally
-    redis_url = env.get('REDIS_URL','redis://local.test:6379')    
-    r = redis.from_url(redis_url)
-    return r
+    redis_url = env.get("REDIS_URL", "redis://local.test:6379")
+    connection_pool = ConnectionPool.from_url(redis_url)
+    redis = Redis(connection_pool=connection_pool, ssl_cert_reqs=None)
+    return redis


### PR DESCRIPTION
This PR updates the Redis connection to ignore the SSL certificate checks. This is required for Heroku deployment (where this is deployed at the moment). If we dont set the `ssl_cert_reqs=None` then the deployment fails see log attached. 

![image](https://github.com/user-attachments/assets/0e70b4b1-d4d0-4980-9fb4-fd096b7cb65c)
